### PR TITLE
Fix to MalformedPolicyDocument error

### DIFF
--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -119,9 +119,9 @@ resource "aws_iam_role" "DefaultHandlerServiceRoleDF00569C" {
             "Action": "execute-api:ManageConnections",
             "Effect": "Allow",
             "Resource": "arn:aws:execute-api:${var.region}:${var.account_id}/*/GET/@connections/*"
-      }
-    ]
-  })
+        }
+        ]
+    })
   }
 
   resource "aws_iam_policy" "manage_connections" {


### PR DESCRIPTION
Changes include:
-comma added to IAM Policy to fix MalformedPolicyDocument error.